### PR TITLE
Repoint Rasputin download links to the site Download page (ADR-0002 Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Static Web Apps via `.github/workflows/`.
 geekdojo's flagship project is **Rasputin**, the open-source homelab cluster
 system — its site lives at [rasputin.geekdojo.com](https://rasputin.geekdojo.com)
 ([source](https://github.com/geekdojo/rasputin-site)), downloads at
-[rasputin-releases](https://github.com/geekdojo/rasputin-releases).
+[rasputin.geekdojo.com/download](https://rasputin.geekdojo.com/download/).
 
 The previous DocFx-based "dojo" content site lives on in this repo's git
 history (pre-2026 commits).

--- a/site/index.html
+++ b/site/index.html
@@ -48,7 +48,7 @@
       control.</p>
       <div class="cta-row">
         <a class="btn btn-primary" href="https://rasputin.geekdojo.com">rasputin.geekdojo.com</a>
-        <a class="btn btn-ghost" href="https://github.com/geekdojo/rasputin-releases">Download on GitHub</a>
+        <a class="btn btn-ghost" href="https://rasputin.geekdojo.com/download/">Download</a>
         <a class="btn btn-ghost" href="https://rasputin.geekdojo.com/devlog/">Devlog</a>
       </div>
     </div>


### PR DESCRIPTION
The company page's Rasputin CTA (`site/index.html`) and README now point at `rasputin.geekdojo.com/download/` instead of the retired `rasputin-releases` mirror.

Part of ADR-0002 Phase 3 (repoint human-facing links off the retired `rasputin-releases` mirror). Outward-facing — publishes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)